### PR TITLE
Always use -use-ocamlfind in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 
     "postinstall": "npm run reasonBuild",
     "buildHelp": "eval $(dependencyEnv) && nopam && rebuild --help",
-    "reasonBuild": "eval $(dependencyEnv) && nopam && rebuild -I src ./src/Test.native 2>&1 | refmterr",
+    "reasonBuild": "eval $(dependencyEnv) && nopam && rebuild -use-ocamlfind -I src ./src/Test.native 2>&1 | refmterr",
     "reasonbuild": "npm run reasonBuild",
 
     "start": "eval $(dependencyEnv) && ./_build/src/Test.native",


### PR DESCRIPTION
-use-ocamlfind has better support with ppx, we should enable it by default.

@vjeux