### PR TITLE
Update Yarn README, `whereisreason` doesn't exist anymore

### DIFF
--- a/README-Yarn.md
+++ b/README-Yarn.md
@@ -122,7 +122,7 @@ We will come up with a long term solution at some point.
   compiled into.
 
 ```
-npm run whereisreason
+npm run whereisocamlmerlin
 ```
 
 


### PR DESCRIPTION
Same as #5, but for Yarn's instructions.